### PR TITLE
Install jupyterlab-widgets for the GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           name: extension-artifacts
       - name: Install the dependencies
         run: |
-          python -m pip install --pre jupyterlite-core jupyter-server jupyterlite_javascript_kernel*.whl
+          python -m pip install --pre jupyterlite-core jupyter-server jupyterlab-widgets jupyterlite_javascript_kernel*.whl
       - name: Build the JupyterLite site
         run: |
           jupyter lite build --output-dir dist --contents examples


### PR DESCRIPTION
Should fix the widgets not displaying on https://jupyterlite.github.io/javascript-kernel/lab/index.html