### PR TITLE
Support startup extensions for JavaScript kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ targets without sending bootstrap code through `requestExecute`.
 
 ```typescript
 import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { IJavaScriptKernelStartup } from '@jupyterlite/javascript-kernel';
+import { IJavaScriptKernelStartupRegistry } from '@jupyterlite/javascript-kernel';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'my-extension:javascript-startup',
   autoStart: true,
-  requires: [IJavaScriptKernelStartup],
+  requires: [IJavaScriptKernelStartupRegistry],
   activate: (app, startup) => {
     const runtimeBootstrap = new URL(
       './runtime-bootstrap.js',
@@ -66,24 +66,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     startup.registerStartupExtension({
       id: 'my-extension:lsp',
-      modulePreloads: [runtimeBootstrap],
-      commTargets: [
-        {
+      activate: async context => {
+        await context.preloadModule(runtimeBootstrap);
+        await context.registerCommTarget({
           targetName: 'my-extension:lsp',
           module: lspCommTarget,
           exportName: 'registerLspTarget'
-        }
-      ]
+        });
+      },
+      deactivate: async context => {
+        await context.unregisterCommTarget('my-extension:lsp');
+      }
     });
   }
 };
 ```
 
-Each `commTargets` entry imports the module in the kernel runtime and passes
-the exported handler to `Jupyter.comm.registerTarget(targetName, handler)`.
-The default export is used when `exportName` is omitted.
-Disposing a startup registration removes declared comm targets from active
-kernels; use an optional `deactivate` callback for extra cleanup.
+`context.registerCommTarget()` imports the module in the kernel runtime and
+passes the exported handler to `Jupyter.comm.registerTarget(targetName,
+handler)`. The default export is used when `exportName` is omitted. Disposing
+a startup registration calls its optional `deactivate` callback for active
+kernels.
 
 ### Worker mode limitations
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,51 @@ The extension currently registers two JavaScript kernelspecs:
 
 Pick either kernel from the notebook kernel selector in JupyterLite.
 
+### Kernel startup extensions
+
+Frontend extensions can register startup work that runs before user code in
+both runtime modes. Use this to preload runtime modules and register comm
+targets without sending bootstrap code through `requestExecute`.
+
+```typescript
+import type { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { IJavaScriptKernelStartup } from '@jupyterlite/javascript-kernel';
+
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'my-extension:javascript-startup',
+  autoStart: true,
+  requires: [IJavaScriptKernelStartup],
+  activate: (app, startup) => {
+    const runtimeBootstrap = new URL(
+      './runtime-bootstrap.js',
+      import.meta.url
+    ).toString();
+    const lspCommTarget = new URL(
+      './lsp-comm-target.js',
+      import.meta.url
+    ).toString();
+
+    startup.registerStartupExtension({
+      id: 'my-extension:lsp',
+      modulePreloads: [runtimeBootstrap],
+      commTargets: [
+        {
+          targetName: 'my-extension:lsp',
+          module: lspCommTarget,
+          exportName: 'registerLspTarget'
+        }
+      ]
+    });
+  }
+};
+```
+
+Each `commTargets` entry imports the module in the kernel runtime and passes
+the exported handler to `Jupyter.comm.registerTarget(targetName, handler)`.
+The default export is used when `exportName` is omitted.
+Disposing a startup registration removes declared comm targets from active
+kernels; use an optional `deactivate` callback for extra cleanup.
+
 ### Worker mode limitations
 
 Web Workers do not expose DOM APIs. In `JavaScript (Web Worker)`, APIs such as `document`, direct element access, and other main-thread-only browser APIs are unavailable.

--- a/packages/javascript-kernel-extension/package.json
+++ b/packages/javascript-kernel-extension/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@jupyterlab/application": "^4.5.5",
     "@jupyterlite/javascript-kernel": "^0.4.0-alpha.4",
-    "@jupyterlite/services": "^0.7.0"
+    "@jupyterlite/services": "^0.7.0",
+    "@lumino/disposable": "^2.1.5"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.5.5",
@@ -56,6 +57,9 @@
     "extension": true,
     "outputDir": "../../jupyterlite_javascript_kernel/labextension",
     "sharedPackages": {
+      "@jupyterlite/javascript-kernel": {
+        "singleton": true
+      },
       "@jupyterlite/services": {
         "bundled": false,
         "singleton": true

--- a/packages/javascript-kernel-extension/package.json
+++ b/packages/javascript-kernel-extension/package.json
@@ -42,7 +42,8 @@
     "@jupyterlab/application": "^4.6.0",
     "@jupyterlite/javascript-kernel": "^0.4.0-alpha.4",
     "@jupyterlite/services": "^0.8.0",
-    "@lumino/disposable": "^2.1.5"
+    "@lumino/disposable": "^2.1.5",
+    "@lumino/signaling": "^2.1.5"
   },
   "devDependencies": {
     "@jupyter/builder": "^1.0.2",

--- a/packages/javascript-kernel-extension/src/index.ts
+++ b/packages/javascript-kernel-extension/src/index.ts
@@ -9,8 +9,13 @@ import {
 import type { IKernel } from '@jupyterlite/services';
 
 import { IKernelSpecs } from '@jupyterlite/services';
+import { DisposableDelegate } from '@lumino/disposable';
+import type { IDisposable } from '@lumino/disposable';
 
-import { JavaScriptKernel } from '@jupyterlite/javascript-kernel';
+import {
+  IJavaScriptKernelStartup,
+  JavaScriptKernel
+} from '@jupyterlite/javascript-kernel';
 import type { RuntimeMode } from '@jupyterlite/javascript-kernel';
 
 import jsLogo32 from '../style/icons/logo-32x32.png';
@@ -24,13 +29,14 @@ interface IRegisterKernelOptions {
   name: string;
   displayName: string;
   runtime: RuntimeMode;
+  startup: IJavaScriptKernelStartup;
 }
 
 const registerKernel = (
   kernelspecs: IKernelSpecs,
   options: IRegisterKernelOptions
 ) => {
-  const { name, displayName, runtime } = options;
+  const { name, displayName, runtime, startup } = options;
 
   kernelspecs.register({
     spec: {
@@ -54,12 +60,92 @@ const registerKernel = (
       }
     },
     create: async (options: IKernel.IOptions): Promise<IKernel> => {
-      return new JavaScriptKernel({
+      const kernel = new JavaScriptKernel({
         ...options,
-        runtime
+        runtime,
+        startupExtensions: startup.startupExtensions
       } as JavaScriptKernel.IOptions);
+      if (startup instanceof JavaScriptKernelStartup) {
+        startup.trackKernel(kernel);
+      }
+      return kernel;
     }
   });
+};
+
+/**
+ * In-memory registry for JavaScript kernel startup extensions.
+ */
+class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
+  get startupExtensions(): readonly JavaScriptKernel.IStartupExtension[] {
+    return [...this._startupExtensions];
+  }
+
+  registerStartupExtension(
+    extension: JavaScriptKernel.IStartupExtension
+  ): IDisposable {
+    const existing = this._startupExtensions.findIndex(
+      item => item.id === extension.id
+    );
+
+    if (existing !== -1) {
+      throw new Error(
+        `JavaScript kernel startup extension "${extension.id}" is already registered`
+      );
+    }
+
+    this._startupExtensions.push(extension);
+    void Promise.all(
+      [...this._kernels].map(kernel => kernel.applyStartupExtension(extension))
+    ).catch(error => {
+      console.error(
+        `[javascript-kernel] Failed to apply startup extension "${extension.id}".`,
+        error
+      );
+    });
+
+    return new DisposableDelegate(() => {
+      const index = this._startupExtensions.indexOf(extension);
+      if (index !== -1) {
+        this._startupExtensions.splice(index, 1);
+        void Promise.all(
+          [...this._kernels].map(kernel =>
+            kernel.removeStartupExtension(extension)
+          )
+        ).catch(error => {
+          console.error(
+            `[javascript-kernel] Failed to remove startup extension "${extension.id}".`,
+            error
+          );
+        });
+      }
+    });
+  }
+
+  /**
+   * Track an active JavaScript kernel for late startup registrations.
+   */
+  trackKernel(kernel: JavaScriptKernel): void {
+    this._kernels.add(kernel);
+    const untrackKernel = (sender: JavaScriptKernel): void => {
+      this._kernels.delete(sender);
+      sender.disposed.disconnect(untrackKernel);
+    };
+    kernel.disposed.connect(untrackKernel);
+  }
+
+  private _startupExtensions: JavaScriptKernel.IStartupExtension[] = [];
+  private _kernels = new Set<JavaScriptKernel>();
+}
+
+/**
+ * Plugin providing the JavaScript kernel startup extension registry.
+ */
+const startupExtensions: JupyterFrontEndPlugin<IJavaScriptKernelStartup> = {
+  id: '@jupyterlite/javascript-kernel-extension:startup-extensions',
+  autoStart: true,
+  provides: IJavaScriptKernelStartup,
+  activate: () => new JavaScriptKernelStartup()
 };
 
 /**
@@ -68,12 +154,17 @@ const registerKernel = (
 const kernelIFrame: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/javascript-kernel-extension:kernel-iframe',
   autoStart: true,
-  requires: [IKernelSpecs],
-  activate: (app: JupyterFrontEnd, kernelspecs: IKernelSpecs) => {
+  requires: [IKernelSpecs, IJavaScriptKernelStartup],
+  activate: (
+    app: JupyterFrontEnd,
+    kernelspecs: IKernelSpecs,
+    startup: IJavaScriptKernelStartup
+  ) => {
     registerKernel(kernelspecs, {
       name: 'javascript',
       displayName: 'JavaScript (IFrame)',
-      runtime: 'iframe'
+      runtime: 'iframe',
+      startup
     });
   }
 };
@@ -84,16 +175,23 @@ const kernelIFrame: JupyterFrontEndPlugin<void> = {
 const kernelWorker: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/javascript-kernel-extension:kernel-worker',
   autoStart: true,
-  requires: [IKernelSpecs],
-  activate: (app: JupyterFrontEnd, kernelspecs: IKernelSpecs) => {
+  requires: [IKernelSpecs, IJavaScriptKernelStartup],
+  activate: (
+    app: JupyterFrontEnd,
+    kernelspecs: IKernelSpecs,
+    startup: IJavaScriptKernelStartup
+  ) => {
     registerKernel(kernelspecs, {
       name: 'javascript-worker',
       displayName: 'JavaScript (Web Worker)',
-      runtime: 'worker'
+      runtime: 'worker',
+      startup
     });
   }
 };
 
-const plugins: JupyterFrontEndPlugin<void>[] = [kernelIFrame, kernelWorker];
+const plugins: Array<
+  JupyterFrontEndPlugin<IJavaScriptKernelStartup> | JupyterFrontEndPlugin<void>
+> = [startupExtensions, kernelIFrame, kernelWorker];
 
 export default plugins;

--- a/packages/javascript-kernel-extension/src/index.ts
+++ b/packages/javascript-kernel-extension/src/index.ts
@@ -125,6 +125,16 @@ class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
    */
   trackKernel(kernel: JavaScriptKernel): void {
     this._kernels.add(kernel);
+    void Promise.all(
+      this._startupExtensions.map(extension =>
+        kernel.applyStartupExtension(extension)
+      )
+    ).catch(error => {
+      console.error(
+        '[javascript-kernel] Failed to apply startup extensions.',
+        error
+      );
+    });
     const untrackKernel = (sender: JavaScriptKernel): void => {
       this._kernels.delete(sender);
       sender.disposed.disconnect(untrackKernel);

--- a/packages/javascript-kernel-extension/src/index.ts
+++ b/packages/javascript-kernel-extension/src/index.ts
@@ -11,9 +11,10 @@ import type { IKernel } from '@jupyterlite/services';
 import { IKernelSpecs } from '@jupyterlite/services';
 import { DisposableDelegate } from '@lumino/disposable';
 import type { IDisposable } from '@lumino/disposable';
+import { Signal } from '@lumino/signaling';
 
 import {
-  IJavaScriptKernelStartup,
+  IJavaScriptKernelStartupRegistry,
   JavaScriptKernel
 } from '@jupyterlite/javascript-kernel';
 import type { RuntimeMode } from '@jupyterlite/javascript-kernel';
@@ -29,14 +30,13 @@ interface IRegisterKernelOptions {
   name: string;
   displayName: string;
   runtime: RuntimeMode;
-  startup: IJavaScriptKernelStartup;
 }
 
 const registerKernel = (
   kernelspecs: IKernelSpecs,
   options: IRegisterKernelOptions
 ) => {
-  const { name, displayName, runtime, startup } = options;
+  const { name, displayName, runtime } = options;
 
   kernelspecs.register({
     spec: {
@@ -63,9 +63,9 @@ const registerKernel = (
       const kernel = new JavaScriptKernel({
         ...options,
         runtime,
-        startupExtensions: startup.startupExtensions
+        startupExtensions: Private.startupExtensions
       } as JavaScriptKernel.IOptions);
-      startup.trackKernel(kernel);
+      Private.kernelCreated.emit(kernel);
       return kernel;
     }
   });
@@ -74,15 +74,15 @@ const registerKernel = (
 /**
  * In-memory registry for JavaScript kernel startup extensions.
  */
-class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
+class JavaScriptKernelStartupRegistry implements IJavaScriptKernelStartupRegistry {
   get startupExtensions(): readonly JavaScriptKernel.IStartupExtension[] {
-    return [...this._startupExtensions];
+    return [...Private.startupExtensions];
   }
 
   registerStartupExtension(
     extension: JavaScriptKernel.IStartupExtension
   ): IDisposable {
-    const existing = this._startupExtensions.findIndex(
+    const existing = Private.startupExtensions.findIndex(
       item => item.id === extension.id
     );
 
@@ -92,9 +92,11 @@ class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
       );
     }
 
-    this._startupExtensions.push(extension);
+    Private.startupExtensions.push(extension);
     void Promise.all(
-      [...this._kernels].map(kernel => kernel.applyStartupExtension(extension))
+      [...Private.kernels].map(kernel =>
+        kernel.applyStartupExtension(extension)
+      )
     ).catch(error => {
       console.error(
         `[javascript-kernel] Failed to apply startup extension "${extension.id}".`,
@@ -103,11 +105,11 @@ class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
     });
 
     return new DisposableDelegate(() => {
-      const index = this._startupExtensions.indexOf(extension);
+      const index = Private.startupExtensions.indexOf(extension);
       if (index !== -1) {
-        this._startupExtensions.splice(index, 1);
+        Private.startupExtensions.splice(index, 1);
         void Promise.all(
-          [...this._kernels].map(kernel =>
+          [...Private.kernels].map(kernel =>
             kernel.removeStartupExtension(extension)
           )
         ).catch(error => {
@@ -119,14 +121,25 @@ class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
       }
     });
   }
+}
+
+namespace Private {
+  export const startupExtensions: JavaScriptKernel.IStartupExtension[] = [];
+  export const kernels = new Set<JavaScriptKernel>();
+
+  const kernelCreatedOwner = {};
+  export const kernelCreated = new Signal<
+    typeof kernelCreatedOwner,
+    JavaScriptKernel
+  >(kernelCreatedOwner);
 
   /**
    * Track an active JavaScript kernel for late startup registrations.
    */
-  trackKernel(kernel: JavaScriptKernel): void {
-    this._kernels.add(kernel);
+  const trackKernel = (kernel: JavaScriptKernel): void => {
+    kernels.add(kernel);
     void Promise.all(
-      this._startupExtensions.map(extension =>
+      startupExtensions.map(extension =>
         kernel.applyStartupExtension(extension)
       )
     ).catch(error => {
@@ -136,25 +149,27 @@ class JavaScriptKernelStartup implements IJavaScriptKernelStartup {
       );
     });
     const untrackKernel = (sender: JavaScriptKernel): void => {
-      this._kernels.delete(sender);
+      kernels.delete(sender);
       sender.disposed.disconnect(untrackKernel);
     };
     kernel.disposed.connect(untrackKernel);
-  }
+  };
 
-  private _startupExtensions: JavaScriptKernel.IStartupExtension[] = [];
-  private _kernels = new Set<JavaScriptKernel>();
+  kernelCreated.connect((_sender, kernel) => {
+    trackKernel(kernel);
+  });
 }
 
 /**
  * Plugin providing the JavaScript kernel startup extension registry.
  */
-const startupExtensions: JupyterFrontEndPlugin<IJavaScriptKernelStartup> = {
-  id: '@jupyterlite/javascript-kernel-extension:startup-extensions',
-  autoStart: true,
-  provides: IJavaScriptKernelStartup,
-  activate: () => new JavaScriptKernelStartup()
-};
+const startupExtensionsRegistry: JupyterFrontEndPlugin<IJavaScriptKernelStartupRegistry> =
+  {
+    id: '@jupyterlite/javascript-kernel-extension:startup-extensions',
+    autoStart: true,
+    provides: IJavaScriptKernelStartupRegistry,
+    activate: () => new JavaScriptKernelStartupRegistry()
+  };
 
 /**
  * Plugin registering the iframe JavaScript kernel.
@@ -162,17 +177,12 @@ const startupExtensions: JupyterFrontEndPlugin<IJavaScriptKernelStartup> = {
 const kernelIFrame: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/javascript-kernel-extension:kernel-iframe',
   autoStart: true,
-  requires: [IKernelSpecs, IJavaScriptKernelStartup],
-  activate: (
-    app: JupyterFrontEnd,
-    kernelspecs: IKernelSpecs,
-    startup: IJavaScriptKernelStartup
-  ) => {
+  requires: [IKernelSpecs],
+  activate: (app: JupyterFrontEnd, kernelspecs: IKernelSpecs) => {
     registerKernel(kernelspecs, {
       name: 'javascript',
       displayName: 'JavaScript (IFrame)',
-      runtime: 'iframe',
-      startup
+      runtime: 'iframe'
     });
   }
 };
@@ -183,23 +193,19 @@ const kernelIFrame: JupyterFrontEndPlugin<void> = {
 const kernelWorker: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/javascript-kernel-extension:kernel-worker',
   autoStart: true,
-  requires: [IKernelSpecs, IJavaScriptKernelStartup],
-  activate: (
-    app: JupyterFrontEnd,
-    kernelspecs: IKernelSpecs,
-    startup: IJavaScriptKernelStartup
-  ) => {
+  requires: [IKernelSpecs],
+  activate: (app: JupyterFrontEnd, kernelspecs: IKernelSpecs) => {
     registerKernel(kernelspecs, {
       name: 'javascript-worker',
       displayName: 'JavaScript (Web Worker)',
-      runtime: 'worker',
-      startup
+      runtime: 'worker'
     });
   }
 };
 
 const plugins: Array<
-  JupyterFrontEndPlugin<IJavaScriptKernelStartup> | JupyterFrontEndPlugin<void>
-> = [startupExtensions, kernelIFrame, kernelWorker];
+  | JupyterFrontEndPlugin<IJavaScriptKernelStartupRegistry>
+  | JupyterFrontEndPlugin<void>
+> = [startupExtensionsRegistry, kernelIFrame, kernelWorker];
 
 export default plugins;

--- a/packages/javascript-kernel-extension/src/index.ts
+++ b/packages/javascript-kernel-extension/src/index.ts
@@ -65,9 +65,7 @@ const registerKernel = (
         runtime,
         startupExtensions: startup.startupExtensions
       } as JavaScriptKernel.IOptions);
-      if (startup instanceof JavaScriptKernelStartup) {
-        startup.trackKernel(kernel);
-      }
+      startup.trackKernel(kernel);
       return kernel;
     }
   });

--- a/packages/javascript-kernel/package.json
+++ b/packages/javascript-kernel/package.json
@@ -47,6 +47,7 @@
     "@jupyterlab/nbformat": "^4.5.0",
     "@jupyterlite/services": "^0.7.0",
     "@lumino/coreutils": "^2.2.2",
+    "@lumino/disposable": "^2.1.5",
     "astring": "^1.9.0",
     "comlink": "^4.3.1",
     "meriyah": "^4.3.9"

--- a/packages/javascript-kernel/src/comm/manager.ts
+++ b/packages/javascript-kernel/src/comm/manager.ts
@@ -77,6 +77,20 @@ export class CommManager {
   }
 
   /**
+   * Whether a comm target handler is registered.
+   */
+  hasTarget(targetName: string): boolean {
+    return this._targets.has(targetName);
+  }
+
+  /**
+   * Remove a comm target handler registration.
+   */
+  unregisterTarget(targetName: string): void {
+    this._targets.delete(targetName);
+  }
+
+  /**
    * Register a widget instance by comm ID.
    */
   registerWidget<T>(commId: string, widget: T): void {

--- a/packages/javascript-kernel/src/executor.ts
+++ b/packages/javascript-kernel/src/executor.ts
@@ -295,12 +295,12 @@ export class JavaScriptExecutor {
   /**
    * Import a module using the executor's import source resolution.
    */
-  async importModule(source: string): Promise<Record<string, any>> {
+  async importModule(source: string): Promise<Record<string, unknown>> {
     const importSource = this._transformImportSource(source);
     const importFunction = this._createScopedFunction(
       'source',
       'return import(source);'
-    ) as (source: string) => Promise<Record<string, any>>;
+    ) as (source: string) => Promise<Record<string, unknown>>;
     return importFunction.call(this._globalScope, importSource);
   }
 

--- a/packages/javascript-kernel/src/executor.ts
+++ b/packages/javascript-kernel/src/executor.ts
@@ -293,6 +293,18 @@ export class JavaScriptExecutor {
   }
 
   /**
+   * Import a module using the executor's import source resolution.
+   */
+  async importModule(source: string): Promise<Record<string, any>> {
+    const importSource = this._transformImportSource(source);
+    const importFunction = this._createScopedFunction(
+      'source',
+      'return import(source);'
+    ) as (source: string) => Promise<Record<string, any>>;
+    return importFunction.call(this._globalScope, importSource);
+  }
+
+  /**
    * Create a new empty code registry.
    */
   createCodeRegistry(): ICodeRegistry {

--- a/packages/javascript-kernel/src/index.ts
+++ b/packages/javascript-kernel/src/index.ts
@@ -9,3 +9,4 @@ export * from './runtime_backends';
 export * from './runtime_evaluator';
 export * from './comm';
 export * from './widgets';
+export * from './startup';

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -533,7 +533,14 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
       this._appliedStartupExtensions.add(extension.id);
     } catch (error) {
       for (const target of registeredTargets.reverse()) {
-        await context.unregisterCommTarget(target.targetName);
+        try {
+          await context.unregisterCommTarget(target.targetName);
+        } catch (rollbackError) {
+          console.warn(
+            `[javascript-kernel] Failed to rollback comm target "${target.targetName}" for startup extension "${extension.id}".`,
+            rollbackError
+          );
+        }
       }
       throw error;
     }

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -299,9 +299,6 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
     try {
       await extension.deactivate?.(context);
     } finally {
-      for (const target of extension.commTargets ?? []) {
-        await context.unregisterCommTarget(target.targetName);
-      }
       this._appliedStartupExtensions.delete(extension.id);
     }
   }
@@ -520,30 +517,8 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
     if (this._appliedStartupExtensions.has(extension.id)) {
       return;
     }
-    const registeredTargets: JavaScriptKernel.IStartupCommTarget[] = [];
-    try {
-      for (const moduleName of extension.modulePreloads ?? []) {
-        await context.preloadModule(moduleName);
-      }
-      for (const target of extension.commTargets ?? []) {
-        await context.registerCommTarget(target);
-        registeredTargets.push(target);
-      }
-      await extension.activate?.(context);
-      this._appliedStartupExtensions.add(extension.id);
-    } catch (error) {
-      for (const target of registeredTargets.reverse()) {
-        try {
-          await context.unregisterCommTarget(target.targetName);
-        } catch (rollbackError) {
-          console.warn(
-            `[javascript-kernel] Failed to rollback comm target "${target.targetName}" for startup extension "${extension.id}".`,
-            rollbackError
-          );
-        }
-      }
-      throw error;
-    }
+    await extension.activate(context);
+    this._appliedStartupExtensions.add(extension.id);
   }
 
   private _unsupportedControlMessages = new Set<'input_reply'>();
@@ -609,9 +584,7 @@ export namespace JavaScriptKernel {
    */
   export interface IStartupExtension {
     id: string;
-    modulePreloads?: readonly string[];
-    commTargets?: readonly IStartupCommTarget[];
-    activate?: (context: IRuntimeReadyContext) => Promise<void> | void;
+    activate: (context: IRuntimeReadyContext) => Promise<void> | void;
     deactivate?: (context: IRuntimeReadyContext) => Promise<void> | void;
   }
 

--- a/packages/javascript-kernel/src/kernel.ts
+++ b/packages/javascript-kernel/src/kernel.ts
@@ -27,6 +27,7 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
     super(options);
     this._runtimeMode = options.runtime ?? 'iframe';
     this._executorFactory = options.executorFactory;
+    this._startupExtensions = [...(options.startupExtensions ?? [])];
     this._backend = this.createBackend(this._runtimeMode);
   }
 
@@ -40,6 +41,8 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
 
     this._comms.clear();
     this._backend.dispose();
+    this._runtimeReadyContext = null;
+    this._appliedStartupExtensions.clear();
     super.dispose();
   }
 
@@ -260,9 +263,47 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
    * Called once a runtime backend is initialized, before `ready` resolves.
    */
   protected async onRuntimeReady(
-    _context: JavaScriptKernel.IRuntimeReadyContext
+    context: JavaScriptKernel.IRuntimeReadyContext
   ): Promise<void> {
-    return Promise.resolve();
+    this._runtimeReadyContext = context;
+    for (const extension of this._startupExtensions) {
+      await this._applyStartupExtension(extension, context);
+    }
+  }
+
+  /**
+   * Apply a startup extension to an initialized runtime.
+   */
+  async applyStartupExtension(
+    extension: JavaScriptKernel.IStartupExtension
+  ): Promise<void> {
+    await this.ready;
+    const context = this._runtimeReadyContext;
+    if (!context) {
+      throw new Error('JavaScript runtime is not initialized');
+    }
+    await this._applyStartupExtension(extension, context);
+  }
+
+  /**
+   * Remove runtime registrations made by a startup extension.
+   */
+  async removeStartupExtension(
+    extension: JavaScriptKernel.IStartupExtension
+  ): Promise<void> {
+    await this.ready;
+    const context = this._runtimeReadyContext;
+    if (!context || !this._appliedStartupExtensions.has(extension.id)) {
+      return;
+    }
+    try {
+      await extension.deactivate?.(context);
+    } finally {
+      for (const target of extension.commTargets ?? []) {
+        await context.unregisterCommTarget(target.targetName);
+      }
+      this._appliedStartupExtensions.delete(extension.id);
+    }
   }
 
   /**
@@ -287,7 +328,16 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
                 throw this._createRuntimeInitializationError(reply);
               }
               return reply;
-            }
+            },
+            preloadModule: context.preloadModule,
+            registerCommTarget: async target => {
+              await context.registerCommTarget(
+                target.targetName,
+                target.module,
+                target.exportName
+              );
+            },
+            unregisterCommTarget: context.unregisterCommTarget
           });
         }
       });
@@ -307,7 +357,16 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
               throw this._createRuntimeInitializationError(reply);
             }
             return reply;
-          }
+          },
+          preloadModule: context.preloadModule,
+          registerCommTarget: async target => {
+            await context.registerCommTarget(
+              target.targetName,
+              target.module,
+              target.exportName
+            );
+          },
+          unregisterCommTarget: context.unregisterCommTarget
         });
       }
     });
@@ -451,10 +510,43 @@ export class JavaScriptKernel extends BaseKernel implements IKernel {
     );
   }
 
+  /**
+   * Apply a startup extension once to the given runtime context.
+   */
+  private async _applyStartupExtension(
+    extension: JavaScriptKernel.IStartupExtension,
+    context: JavaScriptKernel.IRuntimeReadyContext
+  ): Promise<void> {
+    if (this._appliedStartupExtensions.has(extension.id)) {
+      return;
+    }
+    const registeredTargets: JavaScriptKernel.IStartupCommTarget[] = [];
+    try {
+      for (const moduleName of extension.modulePreloads ?? []) {
+        await context.preloadModule(moduleName);
+      }
+      for (const target of extension.commTargets ?? []) {
+        await context.registerCommTarget(target);
+        registeredTargets.push(target);
+      }
+      await extension.activate?.(context);
+      this._appliedStartupExtensions.add(extension.id);
+    } catch (error) {
+      for (const target of registeredTargets.reverse()) {
+        await context.unregisterCommTarget(target.targetName);
+      }
+      throw error;
+    }
+  }
+
   private _unsupportedControlMessages = new Set<'input_reply'>();
   private _comms = new Map<string, { target_name: string }>();
   private _backend: IRuntimeBackend;
   private _executorFactory?: JavaScriptKernel.IExecutorFactory;
+  private _startupExtensions: JavaScriptKernel.IStartupExtension[];
+  private _appliedStartupExtensions = new Set<string>();
+  private _runtimeReadyContext: JavaScriptKernel.IRuntimeReadyContext | null =
+    null;
   private _runtimeMode: RuntimeMode;
 }
 
@@ -468,6 +560,9 @@ export namespace JavaScriptKernel {
   export interface IRuntimeReadyContextBase {
     runtime: RuntimeMode;
     execute: (code: string) => Promise<unknown>;
+    preloadModule: (moduleName: string) => Promise<void>;
+    registerCommTarget: (target: IStartupCommTarget) => Promise<void>;
+    unregisterCommTarget: (targetName: string) => Promise<void>;
   }
 
   /**
@@ -494,6 +589,26 @@ export namespace JavaScriptKernel {
     | IWorkerRuntimeReadyContext;
 
   /**
+   * A comm target handler exported by a startup module.
+   */
+  export interface IStartupCommTarget {
+    targetName: string;
+    module: string;
+    exportName?: string;
+  }
+
+  /**
+   * Startup extension executed before the kernel accepts user code.
+   */
+  export interface IStartupExtension {
+    id: string;
+    modulePreloads?: readonly string[];
+    commTargets?: readonly IStartupCommTarget[];
+    activate?: (context: IRuntimeReadyContext) => Promise<void> | void;
+    deactivate?: (context: IRuntimeReadyContext) => Promise<void> | void;
+  }
+
+  /**
    * Factory used to customize iframe runtime evaluation behavior.
    */
   export type IExecutorFactory = (
@@ -506,5 +621,6 @@ export namespace JavaScriptKernel {
   export interface IOptions extends IKernel.IOptions {
     runtime?: RuntimeMode;
     executorFactory?: IExecutorFactory;
+    startupExtensions?: readonly IStartupExtension[];
   }
 }

--- a/packages/javascript-kernel/src/runtime_backends.ts
+++ b/packages/javascript-kernel/src/runtime_backends.ts
@@ -359,7 +359,12 @@ export class IFrameRuntimeBackend extends AbstractRuntimeBackend {
         globalScope: this._globalScope,
         executor: this._executor,
         execute: (code, executionCount = 0) =>
-          remote.execute(code, executionCount)
+          remote.execute(code, executionCount),
+        preloadModule: moduleName => remote.preloadModule(moduleName),
+        registerCommTarget: (targetName, moduleName, exportName) =>
+          remote.registerCommTarget(targetName, moduleName, exportName),
+        unregisterCommTarget: targetName =>
+          remote.unregisterCommTarget(targetName)
       });
 
       this._ready.resolve();
@@ -412,6 +417,13 @@ export namespace IFrameRuntimeBackend {
       code: string,
       executionCount?: number
     ) => Promise<KernelMessage.IExecuteReplyMsg['content']>;
+    preloadModule: (moduleName: string) => Promise<void>;
+    registerCommTarget: (
+      targetName: string,
+      moduleName: string,
+      exportName?: string
+    ) => Promise<void>;
+    unregisterCommTarget: (targetName: string) => Promise<void>;
   }
 
   /**
@@ -510,7 +522,12 @@ export class WorkerRuntimeBackend extends AbstractRuntimeBackend {
 
       await this._options.onReady?.({
         execute: (code, executionCount = 0) =>
-          remote.execute(code, executionCount)
+          remote.execute(code, executionCount),
+        preloadModule: moduleName => remote.preloadModule(moduleName),
+        registerCommTarget: (targetName, moduleName, exportName) =>
+          remote.registerCommTarget(targetName, moduleName, exportName),
+        unregisterCommTarget: targetName =>
+          remote.unregisterCommTarget(targetName)
       });
 
       this._ready.resolve();
@@ -555,6 +572,13 @@ export namespace WorkerRuntimeBackend {
       code: string,
       executionCount?: number
     ) => Promise<KernelMessage.IExecuteReplyMsg['content']>;
+    preloadModule: (moduleName: string) => Promise<void>;
+    registerCommTarget: (
+      targetName: string,
+      moduleName: string,
+      exportName?: string
+    ) => Promise<void>;
+    unregisterCommTarget: (targetName: string) => Promise<void>;
   }
 
   /**

--- a/packages/javascript-kernel/src/runtime_evaluator.ts
+++ b/packages/javascript-kernel/src/runtime_evaluator.ts
@@ -6,6 +6,7 @@ import type { KernelMessage } from '@jupyterlab/services';
 import { JavaScriptExecutor } from './executor';
 import { normalizeError } from './errors';
 import { CommManager } from './comm';
+import type { CommTargetHandler } from './comm';
 import type { RuntimeOutputHandler } from './runtime_protocol';
 import { Widget, createWidgetClasses } from './widgets';
 
@@ -182,7 +183,7 @@ export class JavaScriptRuntimeEvaluator {
         `Comm target ${targetName} must export a handler function`
       );
     }
-    this._commManager.registerTarget(targetName, handler);
+    this._commManager.registerTarget(targetName, handler as CommTargetHandler);
   }
 
   /**

--- a/packages/javascript-kernel/src/runtime_evaluator.ts
+++ b/packages/javascript-kernel/src/runtime_evaluator.ts
@@ -157,6 +157,42 @@ export class JavaScriptRuntimeEvaluator {
   }
 
   /**
+   * Preload a module in the runtime scope.
+   */
+  async preloadModule(moduleName: string): Promise<void> {
+    await this._executor.importModule(moduleName);
+  }
+
+  /**
+   * Register a comm target handler exported by a runtime module.
+   */
+  async registerCommTarget(
+    targetName: string,
+    moduleName: string,
+    exportName = 'default'
+  ): Promise<void> {
+    if (this._commManager.hasTarget(targetName)) {
+      throw new Error(`Comm target ${targetName} is already registered`);
+    }
+
+    const moduleExports = await this._executor.importModule(moduleName);
+    const handler = moduleExports[exportName];
+    if (typeof handler !== 'function') {
+      throw new TypeError(
+        `Comm target ${targetName} must export a handler function`
+      );
+    }
+    this._commManager.registerTarget(targetName, handler);
+  }
+
+  /**
+   * Remove a comm target handler registration.
+   */
+  unregisterCommTarget(targetName: string): void {
+    this._commManager.unregisterTarget(targetName);
+  }
+
+  /**
    * Handle a comm_open message from the frontend.
    */
   handleCommOpen(

--- a/packages/javascript-kernel/src/runtime_protocol.ts
+++ b/packages/javascript-kernel/src/runtime_protocol.ts
@@ -96,6 +96,13 @@ export interface IRemoteRuntimeApi {
     executionCount: number,
     parentMessageId?: string
   ): Promise<KernelMessage.IExecuteReplyMsg['content']>;
+  preloadModule(moduleName: string): Promise<void>;
+  registerCommTarget(
+    targetName: string,
+    moduleName: string,
+    exportName?: string
+  ): Promise<void>;
+  unregisterCommTarget(targetName: string): Promise<void>;
   complete(
     code: string,
     cursorPos: number

--- a/packages/javascript-kernel/src/runtime_remote.ts
+++ b/packages/javascript-kernel/src/runtime_remote.ts
@@ -59,6 +59,26 @@ export function createRemoteRuntimeApi(
       return ensureEvaluator().execute(code, executionCount, parentMessageId);
     },
 
+    async preloadModule(moduleName: string): Promise<void> {
+      await ensureEvaluator().preloadModule(moduleName);
+    },
+
+    async registerCommTarget(
+      targetName: string,
+      moduleName: string,
+      exportName?: string
+    ): Promise<void> {
+      await ensureEvaluator().registerCommTarget(
+        targetName,
+        moduleName,
+        exportName
+      );
+    },
+
+    async unregisterCommTarget(targetName: string): Promise<void> {
+      ensureEvaluator().unregisterCommTarget(targetName);
+    },
+
     async complete(code: string, cursorPos: number) {
       return ensureEvaluator().complete(code, cursorPos);
     },

--- a/packages/javascript-kernel/src/startup.ts
+++ b/packages/javascript-kernel/src/startup.ts
@@ -9,17 +9,17 @@ import type { JavaScriptKernel } from './kernel';
 /**
  * Registry for JavaScript kernel startup extensions.
  */
-export interface IJavaScriptKernelStartup {
+export interface IJavaScriptKernelStartupRegistry {
   readonly startupExtensions: readonly JavaScriptKernel.IStartupExtension[];
   registerStartupExtension(
     extension: JavaScriptKernel.IStartupExtension
   ): IDisposable;
-  trackKernel(kernel: JavaScriptKernel): void;
 }
 
 /**
  * Token for registering JavaScript kernel startup extensions.
  */
-export const IJavaScriptKernelStartup = new Token<IJavaScriptKernelStartup>(
-  '@jupyterlite/javascript-kernel:IJavaScriptKernelStartup'
-);
+export const IJavaScriptKernelStartupRegistry =
+  new Token<IJavaScriptKernelStartupRegistry>(
+    '@jupyterlite/javascript-kernel:IJavaScriptKernelStartupRegistry'
+  );

--- a/packages/javascript-kernel/src/startup.ts
+++ b/packages/javascript-kernel/src/startup.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Token } from '@lumino/coreutils';
+import type { IDisposable } from '@lumino/disposable';
+
+import type { JavaScriptKernel } from './kernel';
+
+/**
+ * Registry for JavaScript kernel startup extensions.
+ */
+export interface IJavaScriptKernelStartup {
+  readonly startupExtensions: readonly JavaScriptKernel.IStartupExtension[];
+  registerStartupExtension(
+    extension: JavaScriptKernel.IStartupExtension
+  ): IDisposable;
+}
+
+/**
+ * Token for registering JavaScript kernel startup extensions.
+ */
+export const IJavaScriptKernelStartup = new Token<IJavaScriptKernelStartup>(
+  '@jupyterlite/javascript-kernel:IJavaScriptKernelStartup'
+);

--- a/packages/javascript-kernel/src/startup.ts
+++ b/packages/javascript-kernel/src/startup.ts
@@ -14,6 +14,7 @@ export interface IJavaScriptKernelStartup {
   registerStartupExtension(
     extension: JavaScriptKernel.IStartupExtension
   ): IDisposable;
+  trackKernel(kernel: JavaScriptKernel): void;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,7 @@ __metadata:
     "@jupyterlab/builder": ^4.5.5
     "@jupyterlite/javascript-kernel": ^0.4.0-alpha.4
     "@jupyterlite/services": ^0.7.0
+    "@lumino/disposable": ^2.1.5
     npm-run-all2: ^7.0.1
     rimraf: ~5.0.1
     typescript: ~5.0.2
@@ -3683,6 +3684,7 @@ __metadata:
     "@jupyterlab/testutils": ~4.5.0
     "@jupyterlite/services": ^0.7.0
     "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
     "@types/jest": ^26.0.10
     astring: ^1.9.0
     comlink: ^4.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,6 +2995,7 @@ __metadata:
     "@jupyterlite/javascript-kernel": ^0.4.0-alpha.4
     "@jupyterlite/services": ^0.8.0
     "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
     npm-run-all2: ^7.0.1
     rimraf: ~5.0.1
     typescript: ~5.0.2


### PR DESCRIPTION
Closes #28 

This PR adds a first-class startup extension path for JavaScript kernels, allowing integrations to preload modules and register comm targets when kernels start. It also exposes a registration service for extensions and applies startup hooks to new and active kernels.